### PR TITLE
Don't push args when `options.settings` is undefined.

### DIFF
--- a/tasks/django-manage.js
+++ b/tasks/django-manage.js
@@ -82,8 +82,9 @@ module.exports = function (grunt) {
             args.push(options.args.join(' '));
         }
 
-        if (options.settings){
-            settings = '--settings=' + options.app + '.settings.' + options.settings;
+        if (options.settings) {
+            settings = '--settings=' +
+                options.app + '.settings.' + options.settings;
             args.push(settings);
         }
 

--- a/tasks/django-manage.js
+++ b/tasks/django-manage.js
@@ -70,8 +70,7 @@ module.exports = function (grunt) {
         var args = [
                 'python',
                 'manage.py'
-            ],
-            settings = '--settings=';
+            ];
 
         for (var attr in data) {
             options[attr] = data[attr];
@@ -83,8 +82,10 @@ module.exports = function (grunt) {
             args.push(options.args.join(' '));
         }
 
-        settings = settings + options.app + '.settings.' + options.settings;
-        args.push(settings);
+        if (options.settings){
+            settings = '--settings=' + options.app + '.settings.' + options.settings;
+            args.push(settings);
+        }
 
         return args.join(' ');
     }


### PR DESCRIPTION
I want to do this in grunt:

```javascript
    'django-manage': {
        options: {
            app: 'myApp',
            //settings: 'no-settings-for-me.py'
        }
    }
```

But that causes `grunt-django-manage` to go a little wonky, because the task runner assumes that `--settings=` argument will always be used.

I happen to not want to use `--settings=whatever.py` in my particular odd scenario, and so my suggestion is this:

```javascript
       if (options.settings){
            settings = '--settings=' + options.app + '.settings.' + options.settings;
            args.push(settings);
        }
```

My thinking, is that this is a slightly more robust handling of the args anyway.

What are your thoughts? (See code changes below)